### PR TITLE
.pearrc missing issue documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,8 @@ With virtPHP, you may install different PECL extensions, different PEAR packages
 
 ## Known Issues
 
-* .pearrc issue  
-  > If you get an error stating the script couldn't access the `.pearrc` file (or can't find it), you can either try changing the permissions on your `[USER_DIR]/.pearrc` file or remove it entirely. This issue seems to occur sporadically.
+* .pearrc not founc issue  
+  If you get an error stating the script couldn't access the `.pearrc` file (or can't find it), you can either try changing the permissions on your `[USER_DIR]/.pearrc` file or remove it entirely. This issue seems to occur sporadically.
 
 
 ## Contributing


### PR DESCRIPTION
Just adding a "known issues" section to the README with info on how to get around the "missing .pearrc" issue.
