### PR TITLE
Bug fix in environment remove from list.

### DIFF
--- a/src/Virtphp/Workers/Destroyer.php
+++ b/src/Virtphp/Workers/Destroyer.php
@@ -121,9 +121,7 @@ class Destroyer extends AbstractWorker
             // get the env name from path
             $path = $this->getRootPath();
             // make sure the trailing / is removed if autocompleted
-            if (substr($path, -1) === DIRECTORY_SEPARATOR) {
-                $path = substr($path, 0, -1);
-            }
+            $path = rtrim($path, DIRECTORY_SEPARATOR);
             // Convert to an array if full path
             $path = explode(DIRECTORY_SEPARATOR, $path);
             if (is_array($path)) {


### PR DESCRIPTION
When a user was tab-completing path to environment to remove, it was not being removed from the show list due to the trailing slash. This update fixes that and adds a bit more reporting on if the environment was removed from list or not.
