### PR TITLE
Partial fix to Issue #22

### DIFF
--- a/src/Virtphp/Workers/Cloner.php
+++ b/src/Virtphp/Workers/Cloner.php
@@ -268,10 +268,13 @@ class Cloner extends AbstractWorker
         // Convert the contents to array
         $envList = json_decode($envContents, true);
 
+        // Get the pathinfo of the realPath variable
+        $realPathInfo = pathinfo($this->realPath);
+
         // Create new record to add
         $newRecord = array(
             'name' => $this->envName,
-            'path' => $this->realPath,
+            'path' => $realPathInfo['dirname'],
         );
 
         // Add to final object and then write to file


### PR DESCRIPTION
Added 5.3 friendly fix to the realPath value for creating a new record in the environments.json file.

New value writes the path to the environment root folder into the path key's value for storage in the environments.json file.

Tests run and passed.

Thanks @ramsey
