### PR TITLE
Set $COMPOSER_HOME into the virtphp env path

### DIFF
--- a/res/activate.sh
+++ b/res/activate.sh
@@ -100,7 +100,7 @@ fi
 # the Composer settings.
 export VIRTPHP_COMPOSER_GLOBAL="1"
 export VIRTPHP_OLD_COMPOSER_HOME="$COMPOSER_HOME"
-export COMPOSER_HOME="$VIRTPHP_ENV_PATH/.composer"
+export COMPOSER_HOME="$VIRTPHP_ENV_PATH/composer"
 if [ ! -d "$COMPOSER_HOME" ] ; then
   mkdir "$COMPOSER_HOME"
 fi


### PR DESCRIPTION
Setting $COMPOSER_HOME to $VIRTPHP_ENV_PATH/.composer, it would make all `composer global xxx` be executed in the virtphp env path, instead of user's $HOME.
