### PR TITLE
Fixed successful creation message

### DIFF
--- a/src/Virtphp/Command/CreateCommand.php
+++ b/src/Virtphp/Command/CreateCommand.php
@@ -131,7 +131,7 @@ class CreateCommand extends Command
             );
             $output->writeln(
                 '<info>'
-                . "You can activate your new environment using: ~\$ source $installPath/bin/activate"
+                . "You can activate your new environment using: ~\$ source $installPath/$envName/bin/activate"
                 . "</info>\n"
             );
 

--- a/tests/Virtphp/Test/Command/CreateCommandTest.php
+++ b/tests/Virtphp/Test/Command/CreateCommandTest.php
@@ -95,9 +95,13 @@ class CreateCommandTest extends TestCase
             'Your virtual php environment (%s) has been created!',
             $output->messages[0]
         );
-        $this->assertStringMatchesFormat(
-            'You can activate your new environment using: ~$ source %s/bin/activate',
-            $output->messages[1]
+        $this->assertEquals(
+            sprintf(
+                'You can activate your new environment using: ~$ source %s/%s/bin/activate',
+                $input->getOption('install-path'),
+                $input->getArgument('env-name')
+            ),
+            trim($output->messages[1])
         );
     }
 


### PR DESCRIPTION
`virtphp create --install-path="/some/where" envname` outputs `You can activate your new environment using: ~$ source /some/where/bin/activate` instead of `ou can activate your new environment using: ~$ source /some/where/envname/bin/activate`

![screen shot 2014-05-22 at 15 44 30](https://cloud.githubusercontent.com/assets/1788218/3054426/46f1c754-e1b7-11e3-9174-7c8339690ffc.png)
