### PR TITLE
Include php-fpm binary

### DIFF
--- a/res/php-fpm.conf
+++ b/res/php-fpm.conf
@@ -1,0 +1,527 @@
+;;;;;;;;;;;;;;;;;;;;;
+; FPM Configuration ;
+;;;;;;;;;;;;;;;;;;;;;
+
+; All relative paths in this configuration file are relative to PHP's install
+; prefix (/usr/local/Cellar/php55/5.5.15). This prefix can be dynamically changed by using the
+; '-p' argument from the command line.
+
+; Include one or more files. If glob(3) exists, it is used to include a bunch of
+; files from a glob(3) pattern. This directive can be used everywhere in the
+; file.
+; Relative path can also be used. They will be prefixed by:
+;  - the global prefix if it's been set (-p argument)
+;  - /usr/local/Cellar/php55/5.5.15 otherwise
+;include=etc/fpm.d/*.conf
+
+;;;;;;;;;;;;;;;;;;
+; Global Options ;
+;;;;;;;;;;;;;;;;;;
+
+[global]
+; Pid file
+; Note: the default prefix is /usr/local/var
+; Default Value: none
+;pid = run/php-fpm.pid
+
+; Error log file
+; If it's set to "syslog", log is sent to syslogd instead of being written
+; in a local file.
+; Note: the default prefix is /usr/local/var
+; Default Value: log/php-fpm.log
+;error_log = log/php-fpm.log
+
+; syslog_facility is used to specify what type of program is logging the
+; message. This lets syslogd specify that messages from different facilities
+; will be handled differently.
+; See syslog(3) for possible values (ex daemon equiv LOG_DAEMON)
+; Default Value: daemon
+;syslog.facility = daemon
+
+; syslog_ident is prepended to every message. If you have multiple FPM
+; instances running on the same server, you can change the default value
+; which must suit common needs.
+; Default Value: php-fpm
+;syslog.ident = php-fpm
+
+; Log level
+; Possible Values: alert, error, warning, notice, debug
+; Default Value: notice
+;log_level = notice
+
+; If this number of child processes exit with SIGSEGV or SIGBUS within the time
+; interval set by emergency_restart_interval then FPM will restart. A value
+; of '0' means 'Off'.
+; Default Value: 0
+;emergency_restart_threshold = 0
+
+; Interval of time used by emergency_restart_interval to determine when 
+; a graceful restart will be initiated.  This can be useful to work around
+; accidental corruptions in an accelerator's shared memory.
+; Available Units: s(econds), m(inutes), h(ours), or d(ays)
+; Default Unit: seconds
+; Default Value: 0
+;emergency_restart_interval = 0
+
+; Time limit for child processes to wait for a reaction on signals from master.
+; Available units: s(econds), m(inutes), h(ours), or d(ays)
+; Default Unit: seconds
+; Default Value: 0
+;process_control_timeout = 0
+
+; The maximum number of processes FPM will fork. This has been design to control
+; the global number of processes when using dynamic PM within a lot of pools.
+; Use it with caution.
+; Note: A value of 0 indicates no limit
+; Default Value: 0
+; process.max = 128
+
+; Specify the nice(2) priority to apply to the master process (only if set)
+; The value can vary from -19 (highest priority) to 20 (lower priority)
+; Note: - It will only work if the FPM master process is launched as root
+;       - The pool process will inherit the master process priority
+;         unless it specified otherwise
+; Default Value: no set
+; process.priority = -19
+
+; Send FPM to background. Set to 'no' to keep FPM in foreground for debugging.
+; Default Value: yes
+;daemonize = yes
+ 
+; Set open file descriptor rlimit for the master process.
+; Default Value: system defined value
+;rlimit_files = 1024
+ 
+; Set max core size rlimit for the master process.
+; Possible Values: 'unlimited' or an integer greater or equal to 0
+; Default Value: system defined value
+;rlimit_core = 0
+
+; Specify the event mechanism FPM will use. The following is available:
+; - select     (any POSIX os)
+; - poll       (any POSIX os)
+; - epoll      (linux >= 2.5.44)
+; - kqueue     (FreeBSD >= 4.1, OpenBSD >= 2.9, NetBSD >= 2.0)
+; - /dev/poll  (Solaris >= 7)
+; - port       (Solaris >= 10)
+; Default Value: not set (auto detection)
+;events.mechanism = epoll
+
+; When FPM is build with systemd integration, specify the interval,
+; in second, between health report notification to systemd.
+; Set to 0 to disable.
+; Available Units: s(econds), m(inutes), h(ours)
+; Default Unit: seconds
+; Default value: 10
+;systemd_interval = 10
+
+;;;;;;;;;;;;;;;;;;;;
+; Pool Definitions ; 
+;;;;;;;;;;;;;;;;;;;;
+
+; Multiple pools of child processes may be started with different listening
+; ports and different management options.  The name of the pool will be
+; used in logs and stats. There is no limitation on the number of pools which
+; FPM can handle. Your system will tell you anyway :)
+
+; Start a new pool named 'www'.
+; the variable $pool can we used in any directive and will be replaced by the
+; pool name ('www' here)
+[www]
+
+; Per pool prefix
+; It only applies on the following directives:
+; - 'slowlog'
+; - 'listen' (unixsocket)
+; - 'chroot'
+; - 'chdir'
+; - 'php_values'
+; - 'php_admin_values'
+; When not set, the global prefix (or /usr/local/Cellar/php55/5.5.15) applies instead.
+; Note: This directive can also be relative to the global prefix.
+; Default Value: none
+;prefix = /path/to/pools/$pool
+
+; Unix user/group of processes
+; Note: The user is mandatory. If the group is not set, the default user's group
+;       will be used.
+user = _www
+group = _www
+
+; The address on which to accept FastCGI requests.
+; Valid syntaxes are:
+;   'ip.add.re.ss:port'    - to listen on a TCP socket to a specific address on
+;                            a specific port;
+;   'port'                 - to listen on a TCP socket to all addresses on a
+;                            specific port;
+;   '/path/to/unix/socket' - to listen on a unix socket.
+; Note: This value is mandatory.
+listen = 127.0.0.1:9000
+
+; Set listen(2) backlog.
+; Default Value: 65535 (-1 on FreeBSD and OpenBSD)
+;listen.backlog = 65535
+
+; Set permissions for unix socket, if one is used. In Linux, read/write
+; permissions must be set in order to allow connections from a web server. Many
+; BSD-derived systems allow connections regardless of permissions. 
+; Default Values: user and group are set as the running user
+;                 mode is set to 0660
+;listen.owner = _www
+;listen.group = _www
+;listen.mode = 0660
+ 
+; List of ipv4 addresses of FastCGI clients which are allowed to connect.
+; Equivalent to the FCGI_WEB_SERVER_ADDRS environment variable in the original
+; PHP FCGI (5.2.2+). Makes sense only with a tcp listening socket. Each address
+; must be separated by a comma. If this value is left blank, connections will be
+; accepted from any ip address.
+; Default Value: any
+;listen.allowed_clients = 127.0.0.1
+
+; Specify the nice(2) priority to apply to the pool processes (only if set)
+; The value can vary from -19 (highest priority) to 20 (lower priority)
+; Note: - It will only work if the FPM master process is launched as root
+;       - The pool processes will inherit the master process priority
+;         unless it specified otherwise
+; Default Value: no set
+; process.priority = -19
+
+; Choose how the process manager will control the number of child processes.
+; Possible Values:
+;   static  - a fixed number (pm.max_children) of child processes;
+;   dynamic - the number of child processes are set dynamically based on the
+;             following directives. With this process management, there will be
+;             always at least 1 children.
+;             pm.max_children      - the maximum number of children that can
+;                                    be alive at the same time.
+;             pm.start_servers     - the number of children created on startup.
+;             pm.min_spare_servers - the minimum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is less than this
+;                                    number then some children will be created.
+;             pm.max_spare_servers - the maximum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is greater than this
+;                                    number then some children will be killed.
+;  ondemand - no children are created at startup. Children will be forked when
+;             new requests will connect. The following parameter are used:
+;             pm.max_children           - the maximum number of children that
+;                                         can be alive at the same time.
+;             pm.process_idle_timeout   - The number of seconds after which
+;                                         an idle process will be killed.
+; Note: This value is mandatory.
+pm = dynamic
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI. The below defaults are based on a server without much resources. Don't
+; forget to tweak pm.* to fit your needs.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+; Note: This value is mandatory.
+pm.max_children = 5
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
+pm.start_servers = 2
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.min_spare_servers = 1
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.max_spare_servers = 3
+
+; The number of seconds after which an idle process will be killed.
+; Note: Used only when pm is set to 'ondemand'
+; Default Value: 10s
+;pm.process_idle_timeout = 10s;
+ 
+; The number of requests each child process should execute before respawning.
+; This can be useful to work around memory leaks in 3rd party libraries. For
+; endless request processing specify '0'. Equivalent to PHP_FCGI_MAX_REQUESTS.
+; Default Value: 0
+;pm.max_requests = 500
+
+; The URI to view the FPM status page. If this value is not set, no URI will be
+; recognized as a status page. It shows the following informations:
+;   pool                 - the name of the pool;
+;   process manager      - static, dynamic or ondemand;
+;   start time           - the date and time FPM has started;
+;   start since          - number of seconds since FPM has started;
+;   accepted conn        - the number of request accepted by the pool;
+;   listen queue         - the number of request in the queue of pending
+;                          connections (see backlog in listen(2));
+;   max listen queue     - the maximum number of requests in the queue
+;                          of pending connections since FPM has started;
+;   listen queue len     - the size of the socket queue of pending connections;
+;   idle processes       - the number of idle processes;
+;   active processes     - the number of active processes;
+;   total processes      - the number of idle + active processes;
+;   max active processes - the maximum number of active processes since FPM
+;                          has started;
+;   max children reached - number of times, the process limit has been reached,
+;                          when pm tries to start more children (works only for
+;                          pm 'dynamic' and 'ondemand');
+; Value are updated in real time.
+; Example output:
+;   pool:                 www
+;   process manager:      static
+;   start time:           01/Jul/2011:17:53:49 +0200
+;   start since:          62636
+;   accepted conn:        190460
+;   listen queue:         0
+;   max listen queue:     1
+;   listen queue len:     42
+;   idle processes:       4
+;   active processes:     11
+;   total processes:      15
+;   max active processes: 12
+;   max children reached: 0
+;
+; By default the status page output is formatted as text/plain. Passing either
+; 'html', 'xml' or 'json' in the query string will return the corresponding
+; output syntax. Example:
+;   http://www.foo.bar/status
+;   http://www.foo.bar/status?json
+;   http://www.foo.bar/status?html
+;   http://www.foo.bar/status?xml
+;
+; By default the status page only outputs short status. Passing 'full' in the
+; query string will also return status for each pool process.
+; Example: 
+;   http://www.foo.bar/status?full
+;   http://www.foo.bar/status?json&full
+;   http://www.foo.bar/status?html&full
+;   http://www.foo.bar/status?xml&full
+; The Full status returns for each process:
+;   pid                  - the PID of the process;
+;   state                - the state of the process (Idle, Running, ...);
+;   start time           - the date and time the process has started;
+;   start since          - the number of seconds since the process has started;
+;   requests             - the number of requests the process has served;
+;   request duration     - the duration in µs of the requests;
+;   request method       - the request method (GET, POST, ...);
+;   request URI          - the request URI with the query string;
+;   content length       - the content length of the request (only with POST);
+;   user                 - the user (PHP_AUTH_USER) (or '-' if not set);
+;   script               - the main script called (or '-' if not set);
+;   last request cpu     - the %cpu the last request consumed
+;                          it's always 0 if the process is not in Idle state
+;                          because CPU calculation is done when the request
+;                          processing has terminated;
+;   last request memory  - the max amount of memory the last request consumed
+;                          it's always 0 if the process is not in Idle state
+;                          because memory calculation is done when the request
+;                          processing has terminated;
+; If the process is in Idle state, then informations are related to the
+; last request the process has served. Otherwise informations are related to
+; the current request being served.
+; Example output:
+;   ************************
+;   pid:                  31330
+;   state:                Running
+;   start time:           01/Jul/2011:17:53:49 +0200
+;   start since:          63087
+;   requests:             12808
+;   request duration:     1250261
+;   request method:       GET
+;   request URI:          /test_mem.php?N=10000
+;   content length:       0
+;   user:                 -
+;   script:               /home/fat/web/docs/php/test_mem.php
+;   last request cpu:     0.00
+;   last request memory:  0
+;
+; Note: There is a real-time FPM status monitoring sample web page available
+;       It's available in: ${prefix}/share/fpm/status.html
+;
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set 
+;pm.status_path = /status
+ 
+; The ping URI to call the monitoring page of FPM. If this value is not set, no
+; URI will be recognized as a ping page. This could be used to test from outside
+; that FPM is alive and responding, or to
+; - create a graph of FPM availability (rrd or such);
+; - remove a server from a group if it is not responding (load balancing);
+; - trigger alerts for the operating team (24/7).
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set
+;ping.path = /ping
+
+; This directive may be used to customize the response of a ping request. The
+; response is formatted as text/plain with a 200 response code.
+; Default Value: pong
+;ping.response = pong
+
+; The access log file
+; Default: not set
+;access.log = log/$pool.access.log
+
+; The access log format.
+; The following syntax is allowed
+;  %%: the '%' character
+;  %C: %CPU used by the request
+;      it can accept the following format:
+;      - %{user}C for user CPU only
+;      - %{system}C for system CPU only
+;      - %{total}C  for user + system CPU (default)
+;  %d: time taken to serve the request
+;      it can accept the following format:
+;      - %{seconds}d (default)
+;      - %{miliseconds}d
+;      - %{mili}d
+;      - %{microseconds}d
+;      - %{micro}d
+;  %e: an environment variable (same as $_ENV or $_SERVER)
+;      it must be associated with embraces to specify the name of the env
+;      variable. Some exemples:
+;      - server specifics like: %{REQUEST_METHOD}e or %{SERVER_PROTOCOL}e
+;      - HTTP headers like: %{HTTP_HOST}e or %{HTTP_USER_AGENT}e
+;  %f: script filename
+;  %l: content-length of the request (for POST request only)
+;  %m: request method
+;  %M: peak of memory allocated by PHP
+;      it can accept the following format:
+;      - %{bytes}M (default)
+;      - %{kilobytes}M
+;      - %{kilo}M
+;      - %{megabytes}M
+;      - %{mega}M
+;  %n: pool name
+;  %o: output header
+;      it must be associated with embraces to specify the name of the header:
+;      - %{Content-Type}o
+;      - %{X-Powered-By}o
+;      - %{Transfert-Encoding}o
+;      - ....
+;  %p: PID of the child that serviced the request
+;  %P: PID of the parent of the child that serviced the request
+;  %q: the query string 
+;  %Q: the '?' character if query string exists
+;  %r: the request URI (without the query string, see %q and %Q)
+;  %R: remote IP address
+;  %s: status (response code)
+;  %t: server time the request was received
+;      it can accept a strftime(3) format:
+;      %d/%b/%Y:%H:%M:%S %z (default)
+;  %T: time the log has been written (the request has finished)
+;      it can accept a strftime(3) format:
+;      %d/%b/%Y:%H:%M:%S %z (default)
+;  %u: remote user
+;
+; Default: "%R - %u %t \"%m %r\" %s"
+;access.format = "%R - %u %t \"%m %r%Q%q\" %s %f %{mili}d %{kilo}M %C%%"
+ 
+; The log file for slow requests
+; Default Value: not set
+; Note: slowlog is mandatory if request_slowlog_timeout is set
+;slowlog = log/$pool.log.slow
+ 
+; The timeout for serving a single request after which a PHP backtrace will be
+; dumped to the 'slowlog' file. A value of '0s' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+;request_slowlog_timeout = 0
+ 
+; The timeout for serving a single request after which the worker process will
+; be killed. This option should be used when the 'max_execution_time' ini option
+; does not stop script execution for some reason. A value of '0' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+;request_terminate_timeout = 0
+ 
+; Set open file descriptor rlimit.
+; Default Value: system defined value
+;rlimit_files = 1024
+ 
+; Set max core size rlimit.
+; Possible Values: 'unlimited' or an integer greater or equal to 0
+; Default Value: system defined value
+;rlimit_core = 0
+ 
+; Chroot to this directory at the start. This value must be defined as an
+; absolute path. When this value is not set, chroot is not used.
+; Note: you can prefix with '$prefix' to chroot to the pool prefix or one
+; of its subdirectories. If the pool prefix is not set, the global prefix
+; will be used instead.
+; Note: chrooting is a great security feature and should be used whenever 
+;       possible. However, all PHP paths will be relative to the chroot
+;       (error_log, sessions.save_path, ...).
+; Default Value: not set
+;chroot = 
+ 
+; Chdir to this directory at the start.
+; Note: relative path can be used.
+; Default Value: current directory or / when chroot
+;chdir = /var/www
+ 
+; Redirect worker stdout and stderr into main error log. If not set, stdout and
+; stderr will be redirected to /dev/null according to FastCGI specs.
+; Note: on highloaded environement, this can cause some delay in the page
+; process time (several ms).
+; Default Value: no
+;catch_workers_output = yes
+
+; Clear environment in FPM workers
+; Prevents arbitrary environment variables from reaching FPM worker processes
+; by clearing the environment in workers before env vars specified in this
+; pool configuration are added.
+; Setting to "no" will make all environment variables available to PHP code
+; via getenv(), $_ENV and $_SERVER.
+; Default Value: yes
+;clear_env = no
+
+; Limits the extensions of the main script FPM will allow to parse. This can
+; prevent configuration mistakes on the web server side. You should only limit
+; FPM to .php extensions to prevent malicious users to use other extensions to
+; exectute php code.
+; Note: set an empty value to allow all extensions.
+; Default Value: .php
+;security.limit_extensions = .php .php3 .php4 .php5
+ 
+; Pass environment variables like LD_LIBRARY_PATH. All $VARIABLEs are taken from
+; the current environment.
+; Default Value: clean env
+;env[HOSTNAME] = $HOSTNAME
+;env[PATH] = /usr/local/bin:/usr/bin:/bin
+;env[TMP] = /tmp
+;env[TMPDIR] = /tmp
+;env[TEMP] = /tmp
+
+; Additional php.ini defines, specific to this pool of workers. These settings
+; overwrite the values previously defined in the php.ini. The directives are the
+; same as the PHP SAPI:
+;   php_value/php_flag             - you can set classic ini defines which can
+;                                    be overwritten from PHP call 'ini_set'. 
+;   php_admin_value/php_admin_flag - these directives won't be overwritten by
+;                                     PHP call 'ini_set'
+; For php_*flag, valid values are on, off, 1, 0, true, false, yes or no.
+
+; Defining 'extension' will load the corresponding shared extension from
+; extension_dir. Defining 'disable_functions' or 'disable_classes' will not
+; overwrite previously defined php.ini values, but will append the new value
+; instead.
+
+; Note: path INI options can be relative and will be expanded with the prefix
+; (pool, global or /usr/local/Cellar/php55/5.5.15)
+
+; Default Value: nothing is defined by default except the values in php.ini and
+;                specified at startup with the -d argument
+;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f www@my.domain.com
+;php_flag[display_errors] = off
+;php_admin_value[error_log] = /var/log/fpm-php.www.log
+;php_admin_flag[log_errors] = on
+;php_admin_value[memory_limit] = 32M

--- a/src/Virtphp/Command/CreateCommand.php
+++ b/src/Virtphp/Command/CreateCommand.php
@@ -67,7 +67,14 @@ class CreateCommand extends Command
                 . 'WARNING: many of the directory paths in this '
                 . 'file WILL BE OVERRIDDEN in order for virtPHP to work!',
                 null
-            );
+            )
+			->addOption(
+				'fpm-conf',
+				null,
+				InputOption::VALUE_REQUIRED,
+				'Path to a specific php-fpm.conf to use - ',
+				null
+			);
     }
 
     /*
@@ -113,6 +120,7 @@ class CreateCommand extends Command
         );
         $creator->setCustomPhpIni($input->getOption('php-ini'));
         $creator->setCustomPearConf($input->getOption('pear-conf'));
+        $creator->setCustomFpmConf($input->getOption('fpm-conf'));
         if ($creator->execute()) {
             $output->writeln(
                 '<bg=green;options=bold>'

--- a/src/Virtphp/Command/CreateCommand.php
+++ b/src/Virtphp/Command/CreateCommand.php
@@ -68,13 +68,13 @@ class CreateCommand extends Command
                 . 'file WILL BE OVERRIDDEN in order for virtPHP to work!',
                 null
             )
-			->addOption(
-				'fpm-conf',
-				null,
-				InputOption::VALUE_REQUIRED,
-				'Path to a specific php-fpm.conf to use - ',
-				null
-			);
+            ->addOption(
+                'fpm-conf',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Path to a specific php-fpm.conf to use - ',
+                null
+            );
     }
 
     /*
@@ -83,7 +83,7 @@ class CreateCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $envName = $input->getArgument('env-name');
-        $envPath = getenv('HOME') . DIRECTORY_SEPARATOR .  '.virtphp';
+        $envPath = getenv('HOME') . DIRECTORY_SEPARATOR . '.virtphp';
         $envFolder = $envPath . DIRECTORY_SEPARATOR . 'envs';
 
         // Pass the output object to the parent

--- a/src/Virtphp/Workers/Creator.php
+++ b/src/Virtphp/Workers/Creator.php
@@ -55,10 +55,10 @@ class Creator extends AbstractWorker
      */
     protected $customPearConf = null;
 
-	/**
-	 * @var string
-	 */
-	protected $customFpmConf = null;
+    /**
+     * @var string
+     */
+    protected $customFpmConf = null;
 
     /**
      * @var array
@@ -70,24 +70,24 @@ class Creator extends AbstractWorker
      * @var array
      */
     protected static $DEFAULT_PEAR_CONFIG = array(
-        'php_dir'       => '{env_path}/share/php',
-        'data_dir'      => '{env_path}/share/php/data',
-        'www_dir'       => '{env_path}/share/pear/www',
-        'cfg_dir'       => '{env_path}/share/pear/cfg',
-        'ext_dir'       => '{env_path}/lib/php',
-        'doc_dir'       => '{env_path}/share/php/doc',
-        'test_dir'      => '{env_path}/share/pear/tests',
-        'cache_dir'     => '{env_path}/share/pear/cache',
-        'download_dir'  => '{env_path}/share/pear/download',
-        'temp_dir'      => '{env_path}/share/pear/temp',
-        'bin_dir'       => '{env_path}/bin',
-        '__channels'    => array(
+        'php_dir' => '{env_path}/share/php',
+        'data_dir' => '{env_path}/share/php/data',
+        'www_dir' => '{env_path}/share/pear/www',
+        'cfg_dir' => '{env_path}/share/pear/cfg',
+        'ext_dir' => '{env_path}/lib/php',
+        'doc_dir' => '{env_path}/share/php/doc',
+        'test_dir' => '{env_path}/share/pear/tests',
+        'cache_dir' => '{env_path}/share/pear/cache',
+        'download_dir' => '{env_path}/share/pear/download',
+        'temp_dir' => '{env_path}/share/pear/temp',
+        'bin_dir' => '{env_path}/bin',
+        '__channels' => array(
             'pecl.php.net' => array('foo' => '{env_path}/bar'),
-            '__uri'        => array(),
-            'doc.php.net'  => array(),
+            '__uri' => array(),
+            'doc.php.net' => array(),
         ),
-        'php_bin'       => '{env_path}/bin/php',
-        'php_ini'       => '{env_path}/etc/php.ini',
+        'php_bin' => '{env_path}/bin/php',
+        'php_ini' => '{env_path}/etc/php.ini',
         'auto_discover' => 1,
     );
 
@@ -108,7 +108,8 @@ class Creator extends AbstractWorker
         $envName,
         $envBasePath,
         $phpBinDir = null
-    ) {
+    )
+    {
         $this->input = $input;
         $this->output = $output;
         $this->setEnvName($envName);
@@ -221,12 +222,13 @@ class Creator extends AbstractWorker
         return $this->customPearConf;
     }
 
-	/**
-	 * @return string
-	 */
-	public function getCustomFpmConf() {
-		return $this->customFpmConf;
-	}
+    /**
+     * @return string
+     */
+    public function getCustomFpmConf()
+    {
+        return $this->customFpmConf;
+    }
 
     /**
      * @param string $name Name of the new virtual env
@@ -260,10 +262,10 @@ class Creator extends AbstractWorker
         if (!$this->getFilesystem()->exists($dir)) {
             throw new InvalidArgumentException('The specified php bin directory does not exist.');
         }
-        if (!$this->getFilesystem()->exists($dir.DIRECTORY_SEPARATOR.'php')) {
+        if (!$this->getFilesystem()->exists($dir . DIRECTORY_SEPARATOR . 'php')) {
             throw new InvalidArgumentException('There is no php binary in the specified directory.');
         }
-        $process = $this->getProcess($dir.DIRECTORY_SEPARATOR.'php -v');
+        $process = $this->getProcess($dir . DIRECTORY_SEPARATOR . 'php -v');
         if ($process->run() != 0) {
             throw new InvalidArgumentException(
                 'The "php" file in the specified directory is not a valid php binary executable.'
@@ -310,7 +312,7 @@ class Creator extends AbstractWorker
         $this->customPearConf = $pearConfFilePath;
 
         if ($this->customPearConf !== null) {
-            $this->output->writeln('Getting custom pear.conf info from '.$this->customPearConf);
+            $this->output->writeln('Getting custom pear.conf info from ' . $this->customPearConf);
             $pearConfFile = $this->getFilesystem()->getContents($this->customPearConf);
             if ($pearConfFile === false) {
                 throw new InvalidArgumentException('Unable to get contents of custom PEAR config file');
@@ -331,18 +333,19 @@ class Creator extends AbstractWorker
         }
     }
 
-	/**
-	 * @param null $fpmConfFilePath Path to custom php-fpm.conf to use
-	 */
-	public function setCustomFpmConf($fpmConfFilePath = null) {
-		if ($fpmConfFilePath !== null) {
-			$fpmConfFilePath = $this->getFilesystem()->realpath($fpmConfFilePath);
-			if ($fpmConfFilePath === false) {
-				$fpmConfFilePath = null;
-			}
-		}
-		$this->customFpmConf = $fpmConfFilePath;
-	}
+    /**
+     * @param null $fpmConfFilePath Path to custom php-fpm.conf to use
+     */
+    public function setCustomFpmConf($fpmConfFilePath = null)
+    {
+        if ($fpmConfFilePath !== null) {
+            $fpmConfFilePath = $this->getFilesystem()->realpath($fpmConfFilePath);
+            if ($fpmConfFilePath === false) {
+                $fpmConfFilePath = null;
+            }
+        }
+        $this->customFpmConf = $fpmConfFilePath;
+    }
 
 
     /**
@@ -472,7 +475,7 @@ class Creator extends AbstractWorker
     protected function createPhpIni()
     {
         if ($this->getCustomPhpIni() !== null) {
-            $this->output->writeln('Configuring custom php.ini from '.$this->getCustomPhpIni());
+            $this->output->writeln('Configuring custom php.ini from ' . $this->getCustomPhpIni());
             $phpIniPath = $this->getCustomPhpIni();
         } else {
             $this->output->writeln('Creating custom php.ini');
@@ -638,7 +641,7 @@ EOD;
             . '-derror_reporting=1803 -dmemory_limit=-1 -ddetect_unicode=0 '
             . $this->getEnvPath() . DIRECTORY_SEPARATOR . 'share'
             . DIRECTORY_SEPARATOR . 'install-pear-nozlib.phar '
-            . "-d \"".$this->getEnvPath() . DIRECTORY_SEPARATOR . "share"
+            . "-d \"" . $this->getEnvPath() . DIRECTORY_SEPARATOR . "share"
             . DIRECTORY_SEPARATOR . "php\" -b \"bin\" -c \"etc\"";
         $process = $this->getProcess($pearProcess);
 

--- a/src/Virtphp/Workers/Creator.php
+++ b/src/Virtphp/Workers/Creator.php
@@ -55,6 +55,11 @@ class Creator extends AbstractWorker
      */
     protected $customPearConf = null;
 
+	/**
+	 * @var string
+	 */
+	protected $customFpmConf = null;
+
     /**
      * @var array
      */
@@ -216,6 +221,12 @@ class Creator extends AbstractWorker
         return $this->customPearConf;
     }
 
+	/**
+	 * @return string
+	 */
+	public function getCustomFpmConf() {
+		return $this->customFpmConf;
+	}
 
     /**
      * @param string $name Name of the new virtual env
@@ -319,6 +330,19 @@ class Creator extends AbstractWorker
             $this->setPearConfigSettings($this->updatePearConfigSettings($pearConfOptions));
         }
     }
+
+	/**
+	 * @param null $fpmConfFilePath Path to custom php-fpm.conf to use
+	 */
+	public function setCustomFpmConf($fpmConfFilePath = null) {
+		if ($fpmConfFilePath !== null) {
+			$fpmConfFilePath = $this->getFilesystem()->realpath($fpmConfFilePath);
+			if ($fpmConfFilePath === false) {
+				$fpmConfFilePath = null;
+			}
+		}
+		$this->customFpmConf = $fpmConfFilePath;
+	}
 
 
     /**

--- a/src/Virtphp/Workers/Creator.php
+++ b/src/Virtphp/Workers/Creator.php
@@ -375,6 +375,7 @@ class Creator extends AbstractWorker
             $this->installComposer();
             $this->copyActivateScript();
             $this->createPhpFpmBinWrapper();
+            $this->createFpmConf();
         } catch (\Exception $e) {
             $this->output->writeln('<error>ERROR: ' . $e->getMessage() . '</error>');
             $this->getDestroyer()->execute();
@@ -547,6 +548,25 @@ class Creator extends AbstractWorker
             $this->getEnvPath() . DIRECTORY_SEPARATOR . "etc" . DIRECTORY_SEPARATOR . "php.ini",
             $phpIni,
             0644
+        );
+    }
+
+    /**
+     * Creates the new php-fpm.conf for the virtual env
+     */
+    protected function createFpmConf()
+    {
+        if ($this->getCustomPhpIni() !== null) {
+            $this->output->writeln('Configuring custom php-fpm.conf from ' . $this->getCustomFpmConf());
+            $fpmConfPath = $this->getCustomFpmConf();
+        } else {
+            $this->output->writeln('Creating custom php-fpm.conf');
+            $fpmConfPath = __DIR__ . '/../../../res/php-fpm.conf';
+        }
+
+        $this->getFilesystem()->copy(
+            $fpmConfPath,
+            $this->getEnvPath() . DIRECTORY_SEPARATOR . 'etc' . DIRECTORY_SEPARATOR . 'php-fpm.conf'
         );
     }
 

--- a/tests/Virtphp/Test/Command/CreateCommandTest.php
+++ b/tests/Virtphp/Test/Command/CreateCommandTest.php
@@ -35,6 +35,7 @@ class CreateCommandTest extends TestCase
         $this->assertTrue($command->getDefinition()->hasOption('install-path'));
         $this->assertTrue($command->getDefinition()->hasOption('php-ini'));
         $this->assertTrue($command->getDefinition()->hasOption('pear-conf'));
+        $this->assertTrue($command->getDefinition()->hasOption('fpm-conf'));
     }
 
     /**
@@ -76,6 +77,7 @@ class CreateCommandTest extends TestCase
                 '--install-path=/example/foo/bar',
                 '--php-ini=/path/to/php.ini',
                 '--pear-conf=/path/to/pear.conf',
+                '--fpm-conf=/path/to/fpm.conf',
             ),
             $command->getDefinition()
         );
@@ -90,6 +92,7 @@ class CreateCommandTest extends TestCase
         $this->assertEquals('/path/to/php', $creatorMock->args[4]);
         $this->assertEquals('/path/to/php.ini', $creatorMock->phpIni);
         $this->assertEquals('/path/to/pear.conf', $creatorMock->pearConf);
+        $this->assertEquals('/path/to/fpm.conf', $creatorMock->fpmConf);
         $this->assertCount(4, $output->messages);
         $this->assertStringMatchesFormat(
             'Your virtual php environment (%s) has been created!',

--- a/tests/Virtphp/Test/Mock/CreatorMock.php
+++ b/tests/Virtphp/Test/Mock/CreatorMock.php
@@ -5,9 +5,9 @@ class CreatorMock extends WorkerMock
 {
     public $phpIni;
     public $pearConf;
-	public $fpmConf;
+    public $fpmConf;
 
-	public function setCustomPhpIni($phpIni)
+    public function setCustomPhpIni($phpIni)
     {
         $this->phpIni = $phpIni;
     }
@@ -17,7 +17,8 @@ class CreatorMock extends WorkerMock
         $this->pearConf = $pearConf;
     }
 
-	public function setCustomFpmConf($fpmConf) {
-		$this->fpmConf = $fpmConf;
-	}
+    public function setCustomFpmConf($fpmConf)
+    {
+        $this->fpmConf = $fpmConf;
+    }
 }

--- a/tests/Virtphp/Test/Mock/CreatorMock.php
+++ b/tests/Virtphp/Test/Mock/CreatorMock.php
@@ -5,8 +5,9 @@ class CreatorMock extends WorkerMock
 {
     public $phpIni;
     public $pearConf;
+	public $fpmConf;
 
-    public function setCustomPhpIni($phpIni)
+	public function setCustomPhpIni($phpIni)
     {
         $this->phpIni = $phpIni;
     }
@@ -15,4 +16,8 @@ class CreatorMock extends WorkerMock
     {
         $this->pearConf = $pearConf;
     }
+
+	public function setCustomFpmConf($fpmConf) {
+		$this->fpmConf = $fpmConf;
+	}
 }

--- a/tests/Virtphp/Test/Workers/CreatorTest.php
+++ b/tests/Virtphp/Test/Workers/CreatorTest.php
@@ -544,7 +544,7 @@ class CreatorTest extends TestCase
     {
         $filesystemMock = $this->getMock(
             'Virtphp\Test\Mock\FilesystemMock',
-            array('exists')
+            array('exists', 'copy')
         );
         $filesystemMock->expects($this->any())
             ->method('exists')
@@ -613,6 +613,10 @@ class CreatorTest extends TestCase
         );
         $this->assertContains(
             'Installing activate/deactive script',
+            $this->output->messages
+        );
+        $this->assertContains(
+            'Creating custom php-fpm.conf',
             $this->output->messages
         );
     }

--- a/tests/Virtphp/Test/Workers/CreatorTest.php
+++ b/tests/Virtphp/Test/Workers/CreatorTest.php
@@ -246,25 +246,25 @@ class CreatorTest extends TestCase
         $this->assertNull($this->dumbCreator->getCustomPhpIni());
     }
 
-	/**
-	 * @covers Virtphp\Workers\Creator::getCustomFpmConf
-	 * @covers Virtphp\Workers\Creator::getCustomFpmConf
-	 */
-	public function testGetSetCustomFpmConfWithNonNullValue()
-	{
-		$this->assertEmpty($this->dumbCreator->setCustomFpmConf('/path/to/php-fpm.conf'));
-		$this->assertEquals('/path/to/php-fpm.conf', $this->dumbCreator->getCustomFpmConf());
-	}
+    /**
+     * @covers Virtphp\Workers\Creator::getCustomFpmConf
+     * @covers Virtphp\Workers\Creator::getCustomFpmConf
+     */
+    public function testGetSetCustomFpmConfWithNonNullValue()
+    {
+        $this->assertEmpty($this->dumbCreator->setCustomFpmConf('/path/to/php-fpm.conf'));
+        $this->assertEquals('/path/to/php-fpm.conf', $this->dumbCreator->getCustomFpmConf());
+    }
 
-	/**
-	 * @covers Virtphp\Workers\Creator::getCustomFpmConf
-	 * @covers Virtphp\Workers\Creator::setCustomFpmConf
-	 */
-	public function testGetSetCustomFpmConfWithFalseValue()
-	{
-		$this->assertEmpty($this->dumbCreator->setCustomFpmConf(false));
-		$this->assertNull($this->dumbCreator->getCustomFpmConf());
-	}
+    /**
+     * @covers Virtphp\Workers\Creator::getCustomFpmConf
+     * @covers Virtphp\Workers\Creator::setCustomFpmConf
+     */
+    public function testGetSetCustomFpmConfWithFalseValue()
+    {
+        $this->assertEmpty($this->dumbCreator->setCustomFpmConf(false));
+        $this->assertNull($this->dumbCreator->getCustomFpmConf());
+    }
 
     /**
      * @covers Virtphp\Workers\Creator::getPhpBinDir

--- a/tests/Virtphp/Test/Workers/CreatorTest.php
+++ b/tests/Virtphp/Test/Workers/CreatorTest.php
@@ -246,6 +246,26 @@ class CreatorTest extends TestCase
         $this->assertNull($this->dumbCreator->getCustomPhpIni());
     }
 
+	/**
+	 * @covers Virtphp\Workers\Creator::getCustomFpmConf
+	 * @covers Virtphp\Workers\Creator::getCustomFpmConf
+	 */
+	public function testGetSetCustomFpmConfWithNonNullValue()
+	{
+		$this->assertEmpty($this->dumbCreator->setCustomFpmConf('/path/to/php-fpm.conf'));
+		$this->assertEquals('/path/to/php-fpm.conf', $this->dumbCreator->getCustomFpmConf());
+	}
+
+	/**
+	 * @covers Virtphp\Workers\Creator::getCustomFpmConf
+	 * @covers Virtphp\Workers\Creator::setCustomFpmConf
+	 */
+	public function testGetSetCustomFpmConfWithFalseValue()
+	{
+		$this->assertEmpty($this->dumbCreator->setCustomFpmConf(false));
+		$this->assertNull($this->dumbCreator->getCustomFpmConf());
+	}
+
     /**
      * @covers Virtphp\Workers\Creator::getPhpBinDir
      * @covers Virtphp\Workers\Creator::setPhpBinDir

--- a/tests/Virtphp/Test/Workers/CreatorTest.php
+++ b/tests/Virtphp/Test/Workers/CreatorTest.php
@@ -1052,4 +1052,121 @@ EOD;
             $this->output->messages[10]
         );
     }
+
+    public function testFpmBinIsNotCreatedIfPHPWasNotCompileWithIt()
+    {
+        $filesystemMock = $this->getMock(
+            'Virtphp\Test\Mock\FilesystemMock',
+            array('exists', 'dumpFile')
+        );
+        $filesystemMock->expects($this->any())
+            ->method('exists')
+            ->will($this->onConsecutiveCalls(true, true, false, true, true, true, true));
+        $filesystemMock->expects($this->exactly(9))
+            ->method('dumpFile');
+
+        $processMock = $this->getMockBuilder('Virtphp\Test\Mock\ProcessMock')
+            ->disableOriginalConstructor()
+            ->setMethods(array('run'))
+            ->getMock();
+        // php -i | grep 'enable-fpm' exit with non 0 status
+        $processMock->expects($this->at(4))
+            ->method('run')
+            ->will($this->returnValue(1));
+
+        $creator = $this->getMockBuilder('Virtphp\Workers\Creator')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getFilesystem', 'getProcess'))
+            ->getMock();
+        $creator->expects($this->any())
+            ->method('getFilesystem')
+            ->will($this->returnValue($filesystemMock));
+        $creator->expects($this->any())
+            ->method('getProcess')
+            ->will($this->returnValue($processMock));
+
+        $creator->__construct(
+            $this->input,
+            $this->output,
+            'myenv',
+            '/path/to/virtphp/project',
+            '/path/to/bin'
+        );
+
+        $creator->execute();
+
+        $this->assertNotContains(
+            'Wrapping PHP-FPM binary',
+            $this->output->messages
+        );
+    }
+
+    public function testFpmBinIsCreatedIfPHPWasCompileWithIt()
+    {
+        $filesystemMock = $this->getMock(
+            'Virtphp\Test\Mock\FilesystemMock',
+            array('exists', 'dumpFile')
+        );
+        $filesystemMock->expects($this->any())
+            ->method('exists')
+            ->will($this->onConsecutiveCalls(true, true, false, true, true, true, true));
+        $filesystemMock->expects($this->exactly(10))
+            ->method('dumpFile');
+
+        $processMock = $this->getMockBuilder('Virtphp\Test\Mock\ProcessMock')
+            ->disableOriginalConstructor()
+            ->setMethods(array('run'))
+            ->getMock();
+        // php -i | grep 'enable-fpm' exit with non 0 status
+        $processMock->expects($this->at(4))
+            ->method('run')
+            ->will($this->returnValue(0));
+
+        $creator = $this->getMockBuilder('Virtphp\Workers\Creator')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getFilesystem', 'getProcess'))
+            ->getMock();
+        $creator->expects($this->any())
+            ->method('getFilesystem')
+            ->will($this->returnValue($filesystemMock));
+        $creator->expects($this->any())
+            ->method('getProcess')
+            ->will($this->returnValue($processMock));
+
+        $creator->__construct(
+            $this->input,
+            $this->output,
+            'myenv',
+            '/path/to/virtphp/project',
+            '/path/to/bin'
+        );
+
+        $creator->execute();
+
+        $this->assertContains(
+            'Wrapping PHP-FPM binary',
+            $this->output->messages
+        );
+    }
+
+    public function testGetSbinBirShouldReturnTheCorrectDir()
+    {
+        $binPath = '/path/to/php/bin';
+        $filesystemMock = $this->getMock('Virtphp\Test\Mock\FilesystemMock', array('realpath'));
+        $filesystemMock->expects($this->once())
+            ->method('realpath')
+            ->with($binPath . '/../sbin');
+        $creator = $this->getMockBuilder('Virtphp\Workers\Creator')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getFilesystem', 'getPhpBinDir'))
+            ->getMock();
+        $creator->expects($this->any())
+            ->method('getFilesystem')
+            ->will($this->returnValue($filesystemMock));
+        $creator->expects($this->once())
+            ->method('getPhpBinDir')
+            ->will($this->returnValue($binPath));
+
+        $creator->getPhpSbinDir();
+    }
 }


### PR DESCRIPTION
If PHP has been compiled with FPM, it would be nice to include the binary in the `bin` directory of the virtphp env, with the corresponding `php-fpm.conf` in the `etc` directory.
