### PR TITLE
Show Composer failures to humans

### DIFF
--- a/src/Virtphp/Workers/Creator.php
+++ b/src/Virtphp/Workers/Creator.php
@@ -728,7 +728,10 @@ EOD;
         );
 
         if ($process->run() != 0) {
-            throw new \RuntimeException('Could not install Composer.');
+            $errorMessage = $process->getErrorOutput() ?: $process->getOutput();
+            $errorMessage = preg_replace('{^#!/usr/bin/env php\s*}', "", $errorMessage);
+
+            throw new \RuntimeException('Could not install Composer.' . ($errorMessage ? PHP_EOL.$errorMessage : ''));
         }
 
         $this->getFilesystem()->symlink(

--- a/tests/Virtphp/Test/CompilerTest.php
+++ b/tests/Virtphp/Test/CompilerTest.php
@@ -113,7 +113,7 @@ class CompilerTest extends TestCase
         $compiler->expects($this->any())
             ->method('getProcess')
             ->will($this->returnCallback(function ($command) {
-                return new ProcessMock($command, false, -1);
+                return new ProcessMock($command, false, null, -1);
             }));
 
         $compiler->compile($this->testPhar);

--- a/tests/Virtphp/Test/Mock/ProcessMock.php
+++ b/tests/Virtphp/Test/Mock/ProcessMock.php
@@ -4,13 +4,15 @@ namespace Virtphp\Test\Mock;
 class ProcessMock
 {
     public $command;
-    public $output = false;
+    public $stdout;
+    public $stderr;
     public $runReturn = 0;
 
-    public function __construct($command, $output = false, $runReturn = 0)
+    public function __construct($command, $stdout = null, $stderr = null, $runReturn = 0)
     {
         $this->command = $command;
-        $this->output = $output;
+        $this->stdout = $stdout;
+        $this->stderr = $stderr;
         $this->runReturn = $runReturn;
     }
 
@@ -21,6 +23,11 @@ class ProcessMock
 
     public function getOutput()
     {
-        return $this->output;
+        return $this->stdout;
+    }
+
+    public function getErrorOutput()
+    {
+        return $this->stderr;
     }
 }

--- a/tests/Virtphp/Test/Workers/CreatorTest.php
+++ b/tests/Virtphp/Test/Workers/CreatorTest.php
@@ -135,7 +135,7 @@ class CreatorTest extends TestCase
         $creator->expects($this->any())
             ->method('getProcess')
             ->will($this->returnCallback(function ($command) {
-                return new ProcessMock($command, false, 1);
+                return new ProcessMock($command, false, null, 1);
             }));
 
         $creator->__construct($this->input, $this->output, 'myenv', '/foo/bar');
@@ -320,7 +320,7 @@ class CreatorTest extends TestCase
         $creator->expects($this->any())
             ->method('getProcess')
             ->will($this->returnCallback(function ($command) {
-                return new ProcessMock($command, false, 1);
+                return new ProcessMock($command, false, null, 1);
             }));
 
         $creator->setPhpBinDir('/some/path/to/php/that/is/not/valid');


### PR DESCRIPTION
There are so many things that can go wrong, that it would be useful to see what the actual issue was. For me in here (https://github.com/virtphp/virtphp/issues/28#issuecomment-57535448) it was because I was not using a version of PHP that had openssl available. Without me seeing the output I'd never have had a clue about that.
