### PR TITLE
Activate Command

### DIFF
--- a/src/Virtphp/Command/ActivateCommand.php
+++ b/src/Virtphp/Command/ActivateCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of virtPHP.
+ *
+ * (c) Jordan Kasper <github @jakerella>
+ *     Ben Ramsey <github @ramsey>
+ *     Jacques Woodcock <github @jwoodcock>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Virtphp\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Virtphp\Virtphp;
+
+class ActivateCommand extends Command
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('activate')
+            ->setDescription(
+                'Returns the activate file path to be sourced for '
+                . 'the specified environment.'
+            )
+            ->addArgument(
+                'env',
+                InputArgument::REQUIRED,
+                'Which environment do you want to activate'
+            );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+
+        $this->output = $output;
+        $envName = $input->getArgument('env');
+        $envFile = $this->getEnvFile();
+        if (!$envName) {
+            $output->writeln('<error>No environment name was provided.</error>');
+            return false;
+        }
+
+        // Logic for getting the one environment and returning
+        $activator = $this->getWorker('Activator', array(
+            $output,
+            $envName,
+            $envFile
+        ));
+        if ($activator->execute()) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Virtphp/Console/Application.php
+++ b/src/Virtphp/Console/Application.php
@@ -132,6 +132,7 @@ class Application extends BaseApplication
         $commands[] = new Command\CloneCommand();
         $commands[] = new Command\DestroyCommand();
         $commands[] = new Command\ShowCommand();
+        $commands[] = new Command\ActivateCommand();
 
         return $commands;
     }

--- a/src/Virtphp/Workers/Activator.php
+++ b/src/Virtphp/Workers/Activator.php
@@ -41,7 +41,7 @@ class Activator extends AbstractWorker
     /**
      * @var string
      */
-    protected $file = 'environments.json';
+    const FILE = 'environments.json';
 
     /**
      * @var string
@@ -68,7 +68,7 @@ class Activator extends AbstractWorker
         $this->envName = $envName;
         $this->envFile = $envFile;
         $this->envPath = getenv('HOME') . DIRECTORY_SEPARATOR . '.virtphp';
-        $this->filePath = $this->envPath . DIRECTORY_SEPARATOR. $this->file;
+        $this->filePath = $this->envPath . DIRECTORY_SEPARATOR. self::FILE;
         $this->output = $output;
         $this->tableHelper = new TableHelper();
     }

--- a/src/Virtphp/Workers/Activator.php
+++ b/src/Virtphp/Workers/Activator.php
@@ -100,7 +100,7 @@ class Activator extends AbstractWorker
             $path = $envFile['path'] . DIRECTORY_SEPARATOR . $envFile['name']
                 . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'activate';
 
-            // Initiative copy to clipboard process
+            // Initiate copy to clipboard process
             if (!$this->copyToClipboard('source ' . $path)) {
                 $this->output->writeln(
                     '<error>Could not copy the path to your clipboard. '

--- a/src/Virtphp/Workers/Activator.php
+++ b/src/Virtphp/Workers/Activator.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * This file is part of virtPHP.
+ *
+ * (c) Jordan Kasper <github @jakerella>
+ *     Ben Ramsey <github @ramsey>
+ *     Jacques Woodcock <github @jwoodcock>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Virtphp\Workers;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\TableHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Activator extends AbstractWorker
+{
+
+    /**
+     * @var string
+     */
+    protected $envName;
+
+    /**
+     * @var string
+     */
+    protected $envPath;
+
+    /**
+     * @var string
+     */
+    protected $envFile;
+
+    /**
+     * @var string
+     */
+    protected $file = 'environments.json';
+
+    /**
+     * @var string
+     */
+    protected $filePath;
+
+    /**
+     * @var string
+     */
+    protected $tableHelper;
+
+    /**
+     * @var OutputInterface
+     */
+    protected $output;
+
+    /**
+     * Constructs the shower worker
+     *
+     * @param OutputInterface $output
+     */
+    public function __construct(OutputInterface $output, $envName, $envFile)
+    {
+        $this->envName = $envName;
+        $this->envFile = $envFile;
+        $this->envPath = getenv('HOME') . DIRECTORY_SEPARATOR . '.virtphp';
+        $this->filePath = $this->envPath . DIRECTORY_SEPARATOR. $this->file;
+        $this->output = $output;
+        $this->tableHelper = new TableHelper();
+    }
+
+    /**
+     * Function is the guts of the worker, reading the provided
+     * directory and copying those files over.
+     *
+     * @return boolean Whether or not the action was successful
+     */
+    public function execute()
+    {
+        // If a resync was not requested, let's check to make sure we have
+        // a valid json file to read and read it
+        if ($this->getFilesystem()->exists($this->filePath)) {
+
+            // Do a search for the provided environment
+            $envFile = $this->envFile->checkForEnvironment($this->envName);
+
+            // make sure we found the environment
+            if (!$envFile) {
+                $this->output->writeln(
+                    '<error>Could not find the environment you asked for.</error>'
+                );
+                return false;
+            }
+
+            // build source path
+            $path = $envFile['path'] . DIRECTORY_SEPARATOR . $envFile['name']
+                . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'activate';
+
+            // Initiative copy to clipboard process
+            if (!$this->copyToClipboard('source ' . $path)) {
+                $this->output->writeln(
+                    '<error>Could not copy the path to your clipboard. '
+                    . 'Please copy the instructions below.</error>'
+                );
+            } else {
+                $this->output->writeln(
+                    '<info>We were able to save the source command to your '
+                    . 'clipboard. </info>'
+                );
+                $this->output->writeln(
+                    '<info>Just hit your paste command to activate this '
+                    . 'environment or follow the instructions below.</info>'
+                );
+            }
+
+            $this->output->writeln('');
+            $this->output->writeln(
+                '<info>Copy and paste this code to activate your environment.</info>'
+            );
+            $this->output->writeln('<comment>source ' . $path . '</comment>');
+            $this->output->writeln('');
+
+        } else {
+            $this->output->writeln(
+                '<error>either no environments have been created on this system'
+                . ' or the json file has been moved</error>'
+            );
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Method for getting the current OS
+     *
+     */
+    public function getOs()
+    {
+        // get the current os
+        $os = $this->getProcess('uname');
+
+        if ($os->run() == 0) {
+            return $os->getOutput();
+        } else {
+            return 'error';
+        }
+    }
+
+    /**
+     * Method for copying source to the clipboard
+     */
+    public function copyToClipboard($source)
+    {
+        $os = trim($this->getOs());
+
+        if ($os === 'Darwin') {
+            $process = $this->getProcess('echo "' . $source . '" | pbcopy');
+            if ($process->run() == 0) {
+                return true;
+            }
+        } elseif ($os === 'Linux') {
+            $process = $this->getProcess('echo "' . $source . '" | xclip');
+            if ($process->run() == 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Virtphp/Workers/Activator.php
+++ b/src/Virtphp/Workers/Activator.php
@@ -108,12 +108,16 @@ class Activator extends AbstractWorker
                 );
             } else {
                 $this->output->writeln(
-                    '<info>We were able to save the source command to your '
-                    . 'clipboard. </info>'
+                    '<info>Congrats, we were able to save the source command to '
+                    . 'your clipboard. </info>'
                 );
                 $this->output->writeln(
                     '<info>Just hit your paste command to activate this '
                     . 'environment or follow the instructions below.</info>'
+                );
+                $this->output->writeln('');
+                $this->output->writeln(
+                    '<info>or</info>'
                 );
             }
 

--- a/src/Virtphp/Workers/Shower.php
+++ b/src/Virtphp/Workers/Shower.php
@@ -31,7 +31,7 @@ class Shower extends AbstractWorker
     /**
      * @var string
      */
-    protected $file = 'environments.json';
+    const FILE = 'environments.json';
 
     /**
      * @var string
@@ -56,7 +56,7 @@ class Shower extends AbstractWorker
     public function __construct(OutputInterface $output)
     {
         $this->envPath = getenv('HOME') . DIRECTORY_SEPARATOR . '.virtphp';
-        $this->filePath = $this->envPath . DIRECTORY_SEPARATOR. $this->file;
+        $this->filePath = $this->envPath . DIRECTORY_SEPARATOR. self::FILE;
         $this->output = $output;
         $this->tableHelper = new TableHelper();
     }

--- a/tests/Virtphp/Test/Command/ActivateCommandTest.php
+++ b/tests/Virtphp/Test/Command/ActivateCommandTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * This file is part of virtPHP.
+ *
+ * (c) Jordan Kasper <github @jakerella>
+ *     Ben Ramsey <github @ramsey>
+ *     Jacques Woodcock <github @jwoodcock>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Virtphp\Test\Command;
+
+use Symfony\Component\Console\Input\ArgvInput;
+use Virtphp\Command\ActivateCommand;
+use Virtphp\Test\Mock\ActivatorMock;
+use Virtphp\Test\Mock\FilesystemMock;
+use Virtphp\TestCase;
+use Virtphp\TestOutput;
+
+class ActivateCommandTest extends TestCase
+{
+    /**
+     * @covers Virtphp\Command\ActivateCommand::configure
+     */
+    public function testConfigure()
+    {
+        $show = new ActivateCommand();
+
+        $this->assertEquals('activate', $show->getName());
+        $this->assertEquals(
+            'Returns the activate file path to be sourced for '
+            . 'the specified environment.',
+            $show->getDescription()
+        );
+        $this->assertTrue($show->getDefinition()->hasArgument('env'));
+    }
+
+    /**
+     * @covers Virtphp\Command\ActivateCommand::execute
+     */
+    public function testExecute()
+    {
+        $command = $this->getMock(
+            'Virtphp\Command\ActivateCommand', array('getWorker')
+        );
+        $command->expects($this->any())
+            ->method('getWorker')
+            ->will($this->returnCallback(function ($name, $args) {
+                return new ActivatorMock($name, $args);
+            }));
+
+        $execute = new \ReflectionMethod(
+            'Virtphp\Command\ActivateCommand',
+            'execute'
+        );
+        $execute->setAccessible(true);
+
+        $input = new ArgvInput(
+            array(
+                'activate',
+                'envName'
+            ),
+            $command->getDefinition()
+        );
+
+        $output = new TestOutput();
+
+        $result = $execute->invoke($command, $input, $output);
+
+        $this->assertTrue($result);
+        $this->assertCount(0, $output->messages);
+    }
+
+    /**
+     * @covers Virtphp\Command\ActivateCommand::execute
+     */
+    public function testExecuteFail()
+    {
+        $command = $this->getMock(
+            'Virtphp\Command\ActivateCommand', array('getWorker')
+        );
+        $command->expects($this->any())
+            ->method('getWorker')
+            ->will($this->returnCallback(function ($name, $args) {
+                return new ActivatorFailMock($name, $args);
+            }));
+
+        $execute = new \ReflectionMethod(
+            'Virtphp\Command\ActivateCommand',
+            'execute'
+        );
+        $execute->setAccessible(true);
+
+        $input = new ArgvInput(
+            array('action', 'name'),
+            $command->getDefinition()
+        );
+
+        $output = new TestOutput();
+
+        $result = $execute->invoke($command, $input, $output);
+
+        $this->assertFalse($result);
+        $this->assertCount(0, $output->messages);
+    }
+
+    /**
+     * @covers Virtphp\Command\ActivateCommand::execute
+     */
+    public function testExecuteEnvNoEnvironmentName()
+    {
+        $command = $this->getMock(
+            'Virtphp\Command\ActivateCommand', array('getWorker')
+        );
+        $command->expects($this->any())
+            ->method('getWorker')
+            ->will($this->returnCallback(function ($name, $args) {
+                return new ActivatorMock($name, $args);
+            }));
+
+        $execute = new \ReflectionMethod(
+            'Virtphp\Command\ActivateCommand',
+            'execute'
+        );
+        $execute->setAccessible(true);
+
+        $input = new ArgvInput(
+            array('', ''),
+            $command->getDefinition()
+        );
+
+        $output = new TestOutput();
+
+        $result = $execute->invoke($command, $input, $output);
+
+        $this->assertFalse($result);
+        $this->assertCount(1, $output->messages);
+        $this->assertStringMatchesFormat(
+            'No environment name was provided.',
+            $output->messages[0]
+        );
+    }
+}
+
+class ActivatorFailMock
+{
+    public function __construct($output, $envName)
+    {
+        
+    }
+
+    public function execute()
+    {
+        return false;
+    }
+}

--- a/tests/Virtphp/Test/Command/ActivateCommandTest.php
+++ b/tests/Virtphp/Test/Command/ActivateCommandTest.php
@@ -71,7 +71,6 @@ class ActivateCommandTest extends TestCase
         $result = $execute->invoke($command, $input, $output);
 
         $this->assertTrue($result);
-        $this->assertCount(0, $output->messages);
     }
 
     /**

--- a/tests/Virtphp/Test/Mock/ActivatorMock.php
+++ b/tests/Virtphp/Test/Mock/ActivatorMock.php
@@ -1,0 +1,15 @@
+<?php
+namespace Virtphp\Test\Mock;
+
+class ActivatorMock extends WorkerMock
+{
+    public function getOs()
+    {
+        return 'Darwin';
+    }
+
+    public function copyToClipboard($source)
+    {
+        return true;
+    }
+}

--- a/tests/Virtphp/Test/Workers/ActivatorTest.php
+++ b/tests/Virtphp/Test/Workers/ActivatorTest.php
@@ -1,0 +1,244 @@
+<?php
+
+/*
+ * This file is part of virtPHP.
+ *
+ * (c) Jordan Kasper <github @jakerella>
+ *     Ben Ramsey <github @ramsey>
+ *     Jacques Woodcock <github @jwoodcock>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Virtphp\Test\Workers;
+
+use Virtphp\TestCase;
+use Virtphp\TestOutput;
+use Virtphp\Test\Mock\FilesystemMock;
+use Virtphp\Util\Filesystem;
+use Virtphp\Workers\Shower;
+use Virtphp\Test\Mock\TableMock;
+
+class ActivatorTest extends TestCase
+{
+    protected $testClonedEnv = 'tests/testClonedEnv';
+    protected $testOriginalEnv = 'tests/testOriginalEnv';
+    protected $shower;
+    protected $output;
+    protected $filesystemMock;
+    protected $fs;
+
+    protected function setUp()
+    {
+        $this->fs = new Filesystem();
+
+        $this->fs->mkdir($this->testOriginalEnv);
+        $this->fs->mkdir($this->testClonedEnv);
+
+        $this->output = new TestOutput();
+        $this->filesystemMock = $this->getMock(
+            'Virtphp\Test\Mock\FilesystemMock',
+            array('getContents', 'exists')
+        );
+
+        $this->shower = $this->getMockBuilder('Virtphp\Workers\Shower')
+            ->setConstructorArgs(array($this->output))
+            ->setMethods(array('getFilesystem'))
+            ->getMock();
+        $this->shower->expects($this->any())
+            ->method('getFilesystem')
+            ->will($this->returnValue($this->filesystemMock));
+        $this->shower->expects($this->any())
+            ->method('getTableHelper')
+            ->will($this->returnValue(new TableMock()));
+    }
+
+    protected function tearDown()
+    {
+        $this->fs->remove($this->testOriginalEnv);
+        $this->fs->remove($this->testClonedEnv);
+    }
+
+    /**
+     * @covers Virtphp\Workers\Shower::__construct
+     */
+    public function testConstruct()
+    {
+        $shower = new Shower($this->output);
+        $shower->setTableHelper(new TableMock);
+
+        $this->assertInstanceOf('Virtphp\Workers\Shower', $shower);
+        $this->assertInstanceOf(
+            'Virtphp\Test\Mock\TableMock',
+            $shower->getTableHelper()
+        );
+    }
+
+    /**
+     * @covers Virtphp\Workers\Shower::execute
+     * @covers Virtphp\Workers\Shower::setTableHelper
+     * @covers Virtphp\Workers\Shower::getTableHelper
+     */
+    public function testExecute()
+    {
+
+        $this->filesystemMock->expects($this->any())
+            ->method('getContents')
+            ->will($this->returnValue(
+                '{"mytest":{"name":"mytest","path":"\/Users\/virtPHP\/work\/virtphp"}}'
+            ));
+        $this->filesystemMock->expects($this->any())
+            ->method('exists')
+            ->will($this->returnValue(true));
+
+        $this->shower->setTableHelper(new TableMock());
+        $this->assertTrue($this->shower->execute());
+        $this->assertCount(1, $this->output->messages);
+    }
+
+    /**
+     * @covers Virtphp\Workers\Shower::execute
+     */
+    public function testExecuteFailedRealPath()
+    {
+        $filesystemMock = $this->getMock(
+            'Virtphp\Test\Mock\FilesystemMock',
+            array('exists', 'realpath', 'getContents')
+        );
+        $filesystemMock->expects($this->any())
+            ->method('exists')
+            ->will($this->returnValue(true));
+        $filesystemMock->expects($this->any())
+            ->method('realpath')
+            ->will($this->returnValue(false));
+        $filesystemMock->expects($this->any())
+            ->method('getContents')
+            ->will($this->returnValue(
+                '{"mytest":'
+                . '{"name":"mytest",'
+                . '"path":"\/Users\/Kite\/work\/virtphp"},'
+                . '"myenv":{"name":"myenv","path":"\/users\/Kite\/work\/theKit"}}'
+            ));
+
+        $shower = $this->getMockBuilder('Virtphp\Workers\Shower')
+            ->setConstructorArgs(array($this->output))
+            ->setMethods(array('getFilesystem'))
+            ->getMock();
+        $shower->expects($this->any())
+            ->method('getFilesystem')
+            ->will($this->returnValue($filesystemMock));
+
+        $this->assertTrue($shower->execute());
+        $this->assertNotCount(0, $this->output->messages);
+    }
+
+    /**
+     * @covers Virtphp\Workers\Shower::execute
+     */
+    public function testExecuteExceptionReturnsFalse()
+    {
+        $filesystemMock = $this->getMock(
+            'Virtphp\Test\Mock\FilesystemMock',
+            array('exists')
+        );
+        $filesystemMock->expects($this->any())
+            ->method('exists')
+            ->will($this->returnValue(false));
+
+        $shower = $this->getMockBuilder('Virtphp\Workers\Shower')
+            ->setConstructorArgs(array($this->output))
+            ->setMethods(array('getFilesystem'))
+            ->getMock();
+        $shower->expects($this->any())
+            ->method('getFilesystem')
+            ->will($this->returnValue($filesystemMock));
+
+        $this->assertFalse($shower->execute());
+        $this->assertNotCount(0, $this->output->messages);
+    }
+
+    /**
+     * @covers Virtphp\Workers\Shower::updatePath
+     */
+    public function testUpdatePath()
+    {
+
+        $this->filesystemMock->expects($this->any())
+            ->method('getContents')
+            ->will($this->returnValue(
+                '{"mytest":{"name":"mytest","path":"\/Users\/virtPHP\/work\/virtphp"}}'
+            ));
+        $this->filesystemMock->expects($this->any())
+            ->method('exists')
+            ->will($this->returnValue(true));
+
+        $target = 'mytest';
+        $newPath = '\/Users\/Documents\/virtphp';
+
+        $this->shower->setTableHelper(new TableMock());
+        $this->assertTrue($this->shower->updatePath($target, $newPath));
+        $this->assertCount(1, $this->output->messages);
+        $this->assertEquals(
+            $target .' now has the path of ' . $newPath,
+            $this->output->messages[0]
+        );
+    }
+
+    /**
+     * @covers Virtphp\Workers\Shower::updatePath
+     */
+    public function testUpdatePathFail()
+    {
+
+        $this->filesystemMock->expects($this->any())
+            ->method('getContents')
+            ->will($this->returnValue(
+                '{"mytest":{"name":"mytest","path":"\/Users\/virtPHP\/work\/virtphp"}}'
+            ));
+        $this->filesystemMock->expects($this->any())
+            ->method('exists')
+            ->will($this->returnValue(true));
+
+        $target = 'noRecord';
+        $newPath = '\/Users\/Documents\/virtphp';
+
+        $this->shower->setTableHelper(new TableMock());
+        $this->assertFalse($this->shower->updatePath($target, $newPath));
+        $this->assertCount(1, $this->output->messages);
+        $this->assertEquals(
+            $target .' was not found as a valid virtPHP environment.',
+            $this->output->messages[0]
+        );
+    }
+
+    /**
+     * @covers Virtphp\Workers\Shower::updatePath
+     */
+    public function testUpdatePathBadPath()
+    {
+
+        $this->filesystemMock->expects($this->any())
+            ->method('getContents')
+            ->will($this->returnValue(
+                '{"mytest":{"name":"mytest","path":"\/Users\/virtPHP\/work\/virtphp"}}'
+            ));
+        $this->filesystemMock->expects($this->any())
+            ->method('exists')
+            ->will($this->returnValue(true));
+        $this->filesystemMock->expects($this->any())
+            ->method('realpath')
+            ->will($this->returnValue(''));
+
+        $target = 'noRecord';
+        $newPath = '';
+
+        $this->shower->setTableHelper(new TableMock());
+        $this->assertFalse($this->shower->updatePath($target, $newPath));
+        $this->assertCount(1, $this->output->messages);
+        $this->assertEquals(
+            'Path provided is not an actual path.',
+            $this->output->messages[0]
+        );
+    }
+}

--- a/tests/Virtphp/Test/Workers/ActivatorTest.php
+++ b/tests/Virtphp/Test/Workers/ActivatorTest.php
@@ -17,17 +17,19 @@ use Virtphp\TestCase;
 use Virtphp\TestOutput;
 use Virtphp\Test\Mock\FilesystemMock;
 use Virtphp\Util\Filesystem;
-use Virtphp\Workers\Shower;
+use Virtphp\Workers\Activator;
 use Virtphp\Test\Mock\TableMock;
+use Virtphp\Util\EnvironmentFile;
 
 class ActivatorTest extends TestCase
 {
     protected $testClonedEnv = 'tests/testClonedEnv';
     protected $testOriginalEnv = 'tests/testOriginalEnv';
-    protected $shower;
+    protected $activator;
     protected $output;
     protected $filesystemMock;
     protected $fs;
+    protected $envFile; 
 
     protected function setUp()
     {
@@ -41,17 +43,38 @@ class ActivatorTest extends TestCase
             'Virtphp\Test\Mock\FilesystemMock',
             array('getContents', 'exists')
         );
+        $this->envFile = $this->getMock(
+            'Virtphp\Util\EnvironmentFile',
+            array('getFileSystem', 'getEnvironments', 'checkForEnvironment', 'createEnvironmentsFile', 'addEnv', 'removeEnvFromList'),
+            array($this->output),
+            '',
+            false
+        );
 
-        $this->shower = $this->getMockBuilder('Virtphp\Workers\Shower')
-            ->setConstructorArgs(array($this->output))
-            ->setMethods(array('getFilesystem'))
+        $this->envFile->envContents = array(
+            'envName' => array(
+                'name' => 'envName',
+                'path' => '\/Users\/Kite\/.virtphp\/envs',
+            )
+        );
+
+        $this->envFile->expects($this->any())
+            ->method('checkForEnvironment')
+            ->will($this->returnValue(''));
+
+        $this->activator = $this->getMockBuilder('Virtphp\Workers\Activator')
+            ->setConstructorArgs(array($this->output, 'envName', $this->envFile))
+            ->setMethods(array('getFilesystem', 'getOs', 'copyToClipboard'))
             ->getMock();
-        $this->shower->expects($this->any())
+        $this->activator->expects($this->any())
             ->method('getFilesystem')
             ->will($this->returnValue($this->filesystemMock));
-        $this->shower->expects($this->any())
-            ->method('getTableHelper')
-            ->will($this->returnValue(new TableMock()));
+        $this->activator->expects($this->any())
+            ->method('getOs')
+            ->will($this->returnValue(true));
+        $this->activator->expects($this->any())
+            ->method('copyToClipboard')
+            ->will($this->returnValue(true));
     }
 
     protected function tearDown()
@@ -61,46 +84,36 @@ class ActivatorTest extends TestCase
     }
 
     /**
-     * @covers Virtphp\Workers\Shower::__construct
+     * @covers Virtphp\Workers\Activator::__construct
      */
     public function testConstruct()
     {
-        $shower = new Shower($this->output);
-        $shower->setTableHelper(new TableMock);
+        $activator = new Activator($this->output, 'envName', $this->envFile);
 
-        $this->assertInstanceOf('Virtphp\Workers\Shower', $shower);
-        $this->assertInstanceOf(
-            'Virtphp\Test\Mock\TableMock',
-            $shower->getTableHelper()
-        );
+        $this->assertInstanceOf('Virtphp\Workers\Activator', $activator);
+        // for some reason assertNotEquals was not found.
+        $this->assertNotEquals(false, $activator->getOs());
+        $this->assertFalse(false, $activator->copyToClipboard('TestEnv'));
     }
 
     /**
-     * @covers Virtphp\Workers\Shower::execute
-     * @covers Virtphp\Workers\Shower::setTableHelper
-     * @covers Virtphp\Workers\Shower::getTableHelper
+     * @covers Virtphp\Workers\Activator::execute
      */
     public function testExecute()
     {
 
         $this->filesystemMock->expects($this->any())
-            ->method('getContents')
-            ->will($this->returnValue(
-                '{"mytest":{"name":"mytest","path":"\/Users\/virtPHP\/work\/virtphp"}}'
-            ));
-        $this->filesystemMock->expects($this->any())
             ->method('exists')
             ->will($this->returnValue(true));
 
-        $this->shower->setTableHelper(new TableMock());
-        $this->assertTrue($this->shower->execute());
+        $this->assertTrue($this->activator->execute());
         $this->assertCount(1, $this->output->messages);
     }
 
     /**
-     * @covers Virtphp\Workers\Shower::execute
+     * @covers Virtphp\Workers\Activator::execute
      */
-    public function testExecuteFailedRealPath()
+    /*public function testExecuteFailedRealPath()
     {
         $filesystemMock = $this->getMock(
             'Virtphp\Test\Mock\FilesystemMock',
@@ -121,22 +134,22 @@ class ActivatorTest extends TestCase
                 . '"myenv":{"name":"myenv","path":"\/users\/Kite\/work\/theKit"}}'
             ));
 
-        $shower = $this->getMockBuilder('Virtphp\Workers\Shower')
+        $activator = $this->getMockBuilder('Virtphp\Workers\Activator')
             ->setConstructorArgs(array($this->output))
             ->setMethods(array('getFilesystem'))
             ->getMock();
-        $shower->expects($this->any())
+        $activator->expects($this->any())
             ->method('getFilesystem')
             ->will($this->returnValue($filesystemMock));
 
-        $this->assertTrue($shower->execute());
+        $this->assertTrue($activator->execute());
         $this->assertNotCount(0, $this->output->messages);
-    }
+    }*/
 
     /**
-     * @covers Virtphp\Workers\Shower::execute
+     * @covers Virtphp\Workers\Activator::execute
      */
-    public function testExecuteExceptionReturnsFalse()
+    /*public function testExecuteExceptionReturnsFalse()
     {
         $filesystemMock = $this->getMock(
             'Virtphp\Test\Mock\FilesystemMock',
@@ -146,22 +159,22 @@ class ActivatorTest extends TestCase
             ->method('exists')
             ->will($this->returnValue(false));
 
-        $shower = $this->getMockBuilder('Virtphp\Workers\Shower')
+        $activator = $this->getMockBuilder('Virtphp\Workers\Activator')
             ->setConstructorArgs(array($this->output))
             ->setMethods(array('getFilesystem'))
             ->getMock();
-        $shower->expects($this->any())
+        $activator->expects($this->any())
             ->method('getFilesystem')
             ->will($this->returnValue($filesystemMock));
 
-        $this->assertFalse($shower->execute());
+        $this->assertFalse($activator->execute());
         $this->assertNotCount(0, $this->output->messages);
-    }
+    }*/
 
     /**
-     * @covers Virtphp\Workers\Shower::updatePath
+     * @covers Virtphp\Workers\Activator::updatePath
      */
-    public function testUpdatePath()
+    /*public function testUpdatePath()
     {
 
         $this->filesystemMock->expects($this->any())
@@ -176,19 +189,19 @@ class ActivatorTest extends TestCase
         $target = 'mytest';
         $newPath = '\/Users\/Documents\/virtphp';
 
-        $this->shower->setTableHelper(new TableMock());
-        $this->assertTrue($this->shower->updatePath($target, $newPath));
+        $this->activator->setTableHelper(new TableMock());
+        $this->assertTrue($this->activator->updatePath($target, $newPath));
         $this->assertCount(1, $this->output->messages);
         $this->assertEquals(
             $target .' now has the path of ' . $newPath,
             $this->output->messages[0]
         );
-    }
+    }*/
 
     /**
-     * @covers Virtphp\Workers\Shower::updatePath
+     * @covers Virtphp\Workers\Activator::updatePath
      */
-    public function testUpdatePathFail()
+    /*public function testUpdatePathFail()
     {
 
         $this->filesystemMock->expects($this->any())
@@ -203,19 +216,19 @@ class ActivatorTest extends TestCase
         $target = 'noRecord';
         $newPath = '\/Users\/Documents\/virtphp';
 
-        $this->shower->setTableHelper(new TableMock());
-        $this->assertFalse($this->shower->updatePath($target, $newPath));
+        $this->activator->setTableHelper(new TableMock());
+        $this->assertFalse($this->activator->updatePath($target, $newPath));
         $this->assertCount(1, $this->output->messages);
         $this->assertEquals(
             $target .' was not found as a valid virtPHP environment.',
             $this->output->messages[0]
         );
-    }
+    }*/
 
     /**
-     * @covers Virtphp\Workers\Shower::updatePath
+     * @covers Virtphp\Workers\Activator::updatePath
      */
-    public function testUpdatePathBadPath()
+    /*public function testUpdatePathBadPath()
     {
 
         $this->filesystemMock->expects($this->any())
@@ -233,12 +246,12 @@ class ActivatorTest extends TestCase
         $target = 'noRecord';
         $newPath = '';
 
-        $this->shower->setTableHelper(new TableMock());
-        $this->assertFalse($this->shower->updatePath($target, $newPath));
+        $this->activator->setTableHelper(new TableMock());
+        $this->assertFalse($this->activator->updatePath($target, $newPath));
         $this->assertCount(1, $this->output->messages);
         $this->assertEquals(
             'Path provided is not an actual path.',
             $this->output->messages[0]
         );
-    }
+    }*/
 }


### PR DESCRIPTION
Here is the activate command that when used: 

```
virtphp activate {envName}
```

will pull the source path and try to copy to machine clipboard, OSX and Linux, and output the source path just in case the user did not have a compatible clipboard so they can copy and paste it in. 

Full test coverage as well. 